### PR TITLE
Removed unnecessary Cast<T>

### DIFF
--- a/Granular.Common/Extensions/AssemblyExtensions.cs
+++ b/Granular.Common/Extensions/AssemblyExtensions.cs
@@ -16,13 +16,13 @@ namespace Granular.Extensions
 
             if (attributesCache.TryGetValue(assembly.FullName, out attributes))
             {
-                return attributes.OfType<T>().Cast<T>();
+                return attributes.OfType<T>();
             }
 
             attributes = assembly.GetCustomAttributes(false) ?? new object[0];
 
             attributesCache.Add(assembly.FullName, attributes);
-            return attributes.OfType<T>().Cast<T>();
+            return attributes.OfType<T>();
         }
 
         public static T FirstOrDefaultCustomAttributeCached<T>(this Assembly assembly)


### PR DESCRIPTION
 I don't think these two Cast<T> are required and will only add a small perf. hit.